### PR TITLE
Fix naming/lisp-case false positive for gen-class methods

### DIFF
--- a/src/noahtheduke/splint/rules/naming/lisp_case.clj
+++ b/src/noahtheduke/splint/rules/naming/lisp_case.clj
@@ -20,12 +20,13 @@
     (let [def*-name (str sexp)]
       (and (some? (re-find #"(._.|[a-z][A-Z])" def*-name))
         (not (str/includes? def*-name "->"))
-        (not (str/ends-with? def*-name "?"))))))
+        (not (str/ends-with? def*-name "?"))
+        (not (str/starts-with? def*-name "-"))))))
 
 (defrule naming/lisp-case
   "Use lisp-case for function and variable names. (Replacement is generated with [camel-snake-kebab](https://github.com/clj-commons/camel-snake-kebab).)
 
-  Skips names that contain `->` or end in `?`, which indicate conversion functions or type predicates, respectfully.
+  Skips names that contain `->` or end in `?`, which indicate conversion functions or type predicates, respectfully. Also skips names starting with `-`, which are gen-class methods for Java interop.
 
   @safety
   Interop, json, and other styles can make it necessary to use such forms.
@@ -43,7 +44,8 @@
   ; ignores
   (defn StackTraceElement->vec [o] ...)
   (defn NaN? [n] ...)
-  "
+  (defn -handleRequest [_] ...)
+"
   {:pattern '((? def def*??) (? name incorrect-name?) ?*args)
    :message "Prefer kebab-case over other cases for top-level definitions."
    :on-match (fn [ctx rule form {:syms [?def ?name ?args]}]

--- a/test/noahtheduke/splint/rules/naming/lisp_case_test.clj
+++ b/test/noahtheduke/splint/rules/naming/lisp_case_test.clj
@@ -47,4 +47,12 @@
     (expect-match
       nil
       "(defn StackTraceElement->vec [o] ...)"
-      (single-rule-config rule-name))))
+      (single-rule-config rule-name)))
+  (it "ignores gen-class methods"
+    (doseq [input ["(defn -handleRequest [_] :ok)"
+                   "(defn -onCreate [_] nil)"
+                   "(defn -someMethod [this arg] arg)"]]
+      (expect-match
+        nil
+        input
+        (single-rule-config rule-name)))))


### PR DESCRIPTION
## Summary
- Fixed the `naming/lisp-case` rule to skip function names starting with `-` (hyphen)
- These names are required for `gen-class` Java interop (e.g., `-handleRequest` to implement Java methods)
- Added test cases to verify gen-class methods are no longer flagged

## Changes
- Modified `incorrect-name?` function in `lisp_case.clj` to skip names starting with `-`
- Updated rule documentation to explain this exception
- Added test cases for gen-class method patterns

## Test plan
- [x] Existing tests pass
- [x] New tests for gen-class methods pass
- [x] Verified fix resolves the reported issue with the example from #37

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)